### PR TITLE
Implement Filtering, pagination and sorting for links feed - Issue #17

### DIFF
--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -1,5 +1,33 @@
-const feed = (root, args, context, info) => context.prisma.links();
+const feed = async (root, args, context, info) => {
+    const where = args.filter ? {
+        OR: [
+            { description_contains: args.filter },
+            { url_contains: args.filter }
+        ]
+    } : {};
+
+    const links = await context.prisma.links({
+        where,
+        skip: args.skip,
+        first: args.first,
+        orderBy: args.orderBy,
+    });
+
+    const count = await context.prisma.linksConnection({
+        where,
+    }).aggregate()
+        .count();
+
+    return {
+        links,
+        count,
+    }
+}
+
+const link = async (root, args, context, info) =>
+    context.prisma.link({ id: args.id })
 
 export default {
     feed,
+    link,
 };

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,9 +1,12 @@
 type Query{
     info: String!
-    feed:[Link!]!
+    feed(filter: String, skip: Int, first: Int, orderBy: LinkOrderByInput):Feed!
     link(id: ID!):Link
 }
-
+type Feed {
+    links: [Link!]!
+    count: Int!
+}
 type Mutation {
     #signup
     signup(email: String!, password: String!, name: String!): AuthPayload
@@ -55,4 +58,13 @@ type Vote {
     id: ID!
     link: Link!
     user: User!
+}
+
+enum LinkOrderByInput {
+    description_ASC
+    description_DESC
+    url_ASC
+    url_DESC
+    createdAt_ASC
+    createdAt_DESC
 }


### PR DESCRIPTION
#### Description
Implement Filtering, pagination and sorting in order to enable clients set constraints on the list of link elements return by the feed query in the Graphql API

#### Type of change

- [x] New feature (non-breaking change which add a functionality)

#### Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

#### ISSUE
[ISSUE #17](https://github.com/JCanaks/hackernews-node-graphql/issues/17)